### PR TITLE
Add band title after EARFCN in LTE neighbor table

### DIFF
--- a/networksurvey/src/main/res/values/strings.xml
+++ b/networksurvey/src/main/res/values/strings.xml
@@ -105,7 +105,7 @@ but work independently, so you have full control over how you handle your data.<
     <string name="enb_id_label">eNB ID</string>
     <string name="sector_id_label">Sector ID</string>
     <string name="earfcn_band_label">EARFCN/Band</string>
-    <string name="earfcn_label">EARFCN</string>
+    <string name="earfcn_label">EARFCN/Band</string>
     <string name="pci_label">PCI</string>
     <string name="bandwidth_label">Bandwidth</string>
     <string name="ta_label">TA</string>


### PR DESCRIPTION
While testing the debug apk from [9f55acd](https://github.com/christianrowlands/android-network-survey/commit/9f55acd77c2569831965b2d63ca9dcb2b6823f62), I've noticed that "/Band" is also missing in the neighbor table in LTE mode.

![photo_5244658331665160609_y](https://github.com/high3eam/android-network-survey/assets/15855905/6f6ff352-d79d-436b-b0f7-8a602e0005a7)
